### PR TITLE
ASDK-1456: Add HashtagsChannel screen to FeedResources app

### DIFF
--- a/feed_resources/app/build.gradle.kts
+++ b/feed_resources/app/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
     implementation("com.github.bumptech.glide:glide:4.13.2")
 
     // Firework SDK
-    val fireworkSdkVersion = "6.1.0"
+    val fireworkSdkVersion = "6.2.0"
     implementation("com.firework:sdk:$fireworkSdkVersion")
 
     // Glide (optional image loader)

--- a/feed_resources/app/src/main/AndroidManifest.xml
+++ b/feed_resources/app/src/main/AndroidManifest.xml
@@ -29,6 +29,8 @@
 
         <activity android:name=".dynamiccontent.DynamicContentActivity" />
 
+        <activity android:name=".channelhashtags.ChannelHashtagsActivity" />
+
     </application>
 
 </manifest>

--- a/feed_resources/app/src/main/java/com/firework/example/feedresources/MainActivity.kt
+++ b/feed_resources/app/src/main/java/com/firework/example/feedresources/MainActivity.kt
@@ -3,6 +3,7 @@ package com.firework.example.feedresources
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.firework.example.feedresources.channel.ChannelActivity
+import com.firework.example.feedresources.channelhashtags.ChannelHashtagsActivity
 import com.firework.example.feedresources.databinding.ActivityMainBinding
 import com.firework.example.feedresources.discovery.DiscoveryActivity
 import com.firework.example.feedresources.dynamiccontent.DynamicContentActivity
@@ -27,6 +28,9 @@ class MainActivity : AppCompatActivity() {
         }
         binding.dynamicContent.setOnClickListener {
             startActivity(DynamicContentActivity.intent(this))
+        }
+        binding.channelHashtags.setOnClickListener {
+            startActivity(ChannelHashtagsActivity.intent(this))
         }
     }
 }

--- a/feed_resources/app/src/main/java/com/firework/example/feedresources/channelhashtags/ChannelHashtagsActivity.kt
+++ b/feed_resources/app/src/main/java/com/firework/example/feedresources/channelhashtags/ChannelHashtagsActivity.kt
@@ -1,0 +1,85 @@
+package com.firework.example.feedresources.channelhashtags
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import androidx.appcompat.app.AppCompatActivity
+import com.firework.common.feed.FeedResource
+import com.firework.example.feedresources.BuildConfig.FW_CHANNEL_ID
+import com.firework.example.feedresources.R
+import com.firework.example.feedresources.databinding.ActivityChannelHashtagsBinding
+import com.firework.videofeed.FwVideoFeedView
+import com.firework.viewoptions.baseOptions
+import com.firework.viewoptions.viewOptions
+
+class ChannelHashtagsActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityChannelHashtagsBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityChannelHashtagsBinding.inflate(LayoutInflater.from(this))
+        setContentView(binding.root)
+        setTitle(R.string.channel_hashtags_screen_title)
+
+        setupDetails()
+
+        initVideoFeedView()
+
+        binding.etHashtagFilter.setText(HASHTAG_FILTER_EXPRESSION)
+        binding.btnApplyFilter.setOnClickListener {
+            updateViewOptions(binding.etHashtagFilter.text.toString())
+        }
+    }
+
+    @SuppressLint("SetTextI18n")
+    private fun setupDetails() {
+        binding.details.source.text = "Channel"
+        binding.details.channel.text = FW_CHANNEL_ID
+        binding.details.playlist.text = "N/A"
+    }
+
+    private fun initVideoFeedView() {
+        val videoFeedView = binding.fwVideoFeedView
+
+        val viewOptions = viewOptions {
+            baseOptions {
+                feedResource(FeedResource.ChannelHashtag(channelId = FW_CHANNEL_ID, HASHTAG_FILTER_EXPRESSION))
+            }
+        }
+
+        videoFeedView.init(viewOptions)
+    }
+
+    private fun updateViewOptions(hashTagFilter: String) {
+        binding.fwVideoFeedView.destroy()
+        binding.feedContainer.removeAllViews()
+        val videoFeedView = FwVideoFeedView(this)
+        val viewOptions = viewOptions {
+            baseOptions {
+                feedResource(FeedResource.ChannelHashtag(channelId = FW_CHANNEL_ID, hashTagFilter))
+            }
+        }
+        binding.feedContainer.addView(videoFeedView)
+        videoFeedView.init(viewOptions)
+    }
+
+    override fun onDestroy() {
+        binding.fwVideoFeedView.destroy()
+        super.onDestroy()
+    }
+
+    companion object {
+        /**
+         * Hashtag filter expression is an s-expression used to provide feeds filtered by hashtags with specified criteria.
+         * Queries are specified with boolean predicates on what hashtags are there on the video.
+         * For instance, (and sport food) (or sport food) (and sport (or food comedy)) sport are all valid expressions.
+         * Non-UTF-8 characters are not allowed.
+         * If using boolean predicates, the expression needs to be wrapped with parenthesis.
+         */
+        private const val HASHTAG_FILTER_EXPRESSION = "(or food art cats pets beauty fashion travel)"
+
+        fun intent(context: Context) = Intent(context, ChannelHashtagsActivity::class.java)
+    }
+}

--- a/feed_resources/app/src/main/res/layout/activity_channel_hashtags.xml
+++ b/feed_resources/app/src/main/res/layout/activity_channel_hashtags.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.firework.example.feedresources.channelhashtags.ChannelHashtagsActivity">
+
+    <TextView
+        android:id="@+id/tvHashtagExpressionLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/channel_hashtag_filter_expression"
+        android:textAppearance="@style/TextAppearance.AppCompat.Large"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/topContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="16dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@+id/tvHashtagExpressionLabel">
+
+        <EditText
+            android:id="@+id/etHashtagFilter"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/fw__gnt_blue"
+            android:hint="@string/enter_hashtag_filter_expression"
+            tools:ignore="Autofill,TextFields" />
+
+        <Button
+            android:id="@+id/btnApplyFilter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/search" />
+    </LinearLayout>
+
+
+    <FrameLayout
+        android:id="@+id/feedContainer"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/details"
+        app:layout_constraintTop_toBottomOf="@id/topContainer">
+
+        <com.firework.videofeed.FwVideoFeedView
+            android:id="@+id/fwVideoFeedView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
+
+    <include
+        android:id="@+id/details"
+        layout="@layout/details"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feed_resources/app/src/main/res/layout/activity_main.xml
+++ b/feed_resources/app/src/main/res/layout/activity_main.xml
@@ -46,10 +46,21 @@
         android:layout_width="200dp"
         android:layout_height="75dp"
         android:text="@string/dynamic_content"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/channelHashtags"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/playlist" />
+
+    <Button
+        android:id="@+id/channelHashtags"
+        android:layout_width="200dp"
+        android:layout_height="75dp"
+        android:text="@string/channel_hashtags"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/dynamicContent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feed_resources/app/src/main/res/values/strings.xml
+++ b/feed_resources/app/src/main/res/values/strings.xml
@@ -3,14 +3,19 @@
 
     <string name="source_type">Source Type:</string>
     <string name="channel_id">Channel ID:</string>
+    <string name="channel_hashtag_filter_expression">Hashtag Filter Expression:</string>
     <string name="playlist_id">Playlist ID:</string>
     <string name="categories">Categories:</string>
     <string name="discovery">Discovery</string>
     <string name="channel">Channel</string>
     <string name="playlist">Playlist</string>
     <string name="dynamic_content">Dynamic content</string>
+    <string name="channel_hashtags">Channel hashtags</string>
     <string name="discovery_screen_title">FW Discovery</string>
     <string name="playlist_screen_title">FW Playlist</string>
     <string name="channel_screen_title">FW Channel</string>
+    <string name="channel_hashtags_screen_title">FW Channel Hashtags</string>
     <string name="dynamic_content_screen_title">FW Dynamic Content</string>
+    <string name="enter_hashtag_filter_expression">Enter hashtag filter expression</string>
+    <string name="search">Search</string>
 </resources>


### PR DESCRIPTION
**What**
Add HashtagsChannel screen to FeedResources app
The readme will be updated in separate PR.

**Why**
- ASDK-1456


**How**
Add new activity to the FeedResources app. Activity has input field where user can insert filtering expression.

❗ Looks like we do not have a way to update the viewOptions after the initialisation. That's why I had to replace instance of FwVideoFeedView every time new hashtags should be shown.
I created a discussion for this: 
https://github.com/loopsocial/firework_sdk_v2/discussions/2020

**Video**

https://user-images.githubusercontent.com/101661405/233987833-fd5d8257-f162-4fef-90ea-441c26113873.mp4
